### PR TITLE
add blocks parameter to mice

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ RUN apt update && \
 RUN R -e "install.packages('RestRserve', repos = 'https://cloud.r-project.org')"
 RUN R -e "install.packages('jsonlite')"
 RUN R -e "install.packages('remotes')"
-RUN R -e "remotes::install_github('amices/mice')"
+RUN R -e "remotes::install_github('amices/mice', ref='support_blocks')"
 
 # Pull in webmice code
 RUN mkdir /home/webmice

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,7 @@ ENV WEBMICE_LOC="/home/webmice"
 COPY webmice.R /home/webmice/webmice.R
 COPY webmice_handlers.R /home/webmice/webmice_handlers.R
 COPY webmice_functions.R /home/webmice/webmice_functions.R
+COPY sanitize_input.R /home/webmice/sanitize_input.R
 COPY ../openapi.yaml /home/webmice/openapi.yaml
 
 WORKDIR /home/webmice

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -52,7 +52,9 @@ paths:
             text/json:
               schema:
                 type: string
-                example: {"success":[true],"result":[{"age":1},{"age":2,"bmi":22.7,"hyp":1,"chl":187}, {"age":1,"hyp":1,"chl":187},{"age":3},{"age":2,"bmi":27.4,"hyp":1,"chl":186}],"error":[""]}
+                example: {"success":[true],"result":[{"age":1},{"age":2,"bmi":22.7,"hyp":1,"chl":187},
+                    {"age":1,"hyp":1,"chl":187},{"age":3},
+                    {"age":2,"bmi":27.4,"hyp":1,"chl":186}],"error":[""]}
   
   /data:
     post:
@@ -83,11 +85,14 @@ paths:
       description: Run mice imputation on a datasets (nhanes, nhanes2) or an own csv file.
       parameters:
         - name: "payload"
-          description: "Json with keys \"data\", \"maxit\", \"m\", \"seed\", \"predictorMatrix\" (optional)" 
+          description: "Json with keys \"data\", \"maxit\", \"m\", \"seed\", 
+              \"predictorMatrix\" (optional), \"blocks\" (optional)" 
           in: query
           schema:
             type: string
-          example: "{\"data\":\"nhanes\",\"maxit\":2,\"m\":2,\"seed\":1, \"predictorMatrix\":[[0,1,1,1],[1,0,1,1],[1,1,0,1],[1,1,1,0]]}"
+          example: "{\"data\":\"nhanes\",\"maxit\":2,\"m\":2,\"seed\":1,
+          \"predictorMatrix\":[[0,1,1,1],[1,0,1,1],[1,1,0,1],[1,1,1,0]],
+          \"blocks\": {\"b1\": [\"chl\", \"hyp\"], \"b2\": [\"bmi\"]}}"
           required: true
       responses:
         200:
@@ -96,7 +101,12 @@ paths:
             text/json:
               schema:
                 type: string
-                example: {"result":[{"age":1,"bmi":30.1,"hyp":1,"chl":187,".imp":1,".id":"1"    },{"age":2,"bmi":22.7,"hyp":1,"chl":187,".imp":1,".id":"2"},{"age":1,"bmi":27.5,"hyp":1,"chl":131,".imp":2,".id":"23"},{"age":3,"    bmi":24.9,"hyp":1,"chl":218,".imp":2,".id":"24"},{"age":2,"bmi":27.4,"hyp":1,"chl":186,".imp    ":2,".id":"25"}],"error":[""],"success":[true]}
+                example: {"result":[{"age":1,"bmi":30.1,"hyp":1,"chl":187,".imp":1,".id":"1"},
+                    {"age":2,"bmi":22.7,"hyp":1,"chl":187,".imp":1,".id":"2"},
+                    {"age":1,"bmi":27.5,"hyp":1,"chl":131,".imp":2,".id":"23"},
+                    {"age":3," bmi":24.9,"hyp":1,"chl":218,".imp":2,".id":"24"},
+                    {"age":2,"bmi":27.4,"hyp":1,"chl":186,".imp":2,".id":"25"}],
+                    "error":[""],"success":[true]}
   
   /fit:
     get:
@@ -109,7 +119,8 @@ paths:
           in: query
           schema:
             type: string
-          example: "{\"data\": [{\".imp\":1,\".id\":1,\"age\":1,\"bmi\":30.1,\"hyp\":1,\"chl\":187}], \"model\":[\"lm\"], \"formula\":[\"chl ~ age + bmi\"]}"
+          example: "{\"data\": [{\".imp\":1,\".id\":1,\"age\":1,\"bmi\":30.1,\"hyp\":1,\"chl\":187}],
+              \"model\":[\"lm\"], \"formula\":[\"chl ~ age + bmi\"]}"
           required: true
       responses:
         200:
@@ -118,7 +129,10 @@ paths:
             text/json:
               schema:
                 type: string
-                example: {"result":{"call":{},"terms":{},"residuals":[0],"coefficients":[[187,"NaN","NaN","NaN"]],"aliased":[false,true,true],"sigma":["NaN"],"df":[1,0,3],"adj.r.squared":[0],"r.squared":[0],"cov.unscaled":[[1]]},"error":[""],"success":[true]}
+                example: {"result":{"call":{},"terms":{},"residuals":[0],
+                    "coefficients":[[187,"NaN","NaN","NaN"]],"aliased":[false,true,true],
+                    "sigma":["NaN"],"df":[1,0,3],"adj.r.squared":[0],"r.squared":[0],
+                    "cov.unscaled":[[1]]},"error":[""],"success":[true]}
 
   /pool:
     get:
@@ -132,7 +146,16 @@ paths:
           in: query
           schema:
             type: string
-          example: "{\"data\": [{\"term\":\"(Intercept)\",\"estimate\":23.9357,\"std.error\":3.8732,\"statistic\":6.1798,\"p.value\":3.2106e-06,\"nobs\":25,\"df.residual\":22},{\"term\":\"hyp\",\"estimate\":1.1677,\"std.error\":1.6218,\"statistic\":0.72,\"p.value\":0.4791,\"nobs\":25,\"df.residual\":22},{\"term\":\"chl\",\"estimate\":0.0063,\"std.error\":0.0185,\"statistic\":0.3385,\"p.value\":0.7382,\"nobs\":25,\"df.residual\":22},{\"term\":\"(Intercept)\",\"estimate\":24.5434,\"std.error\":4.7611,\"statistic\":5.155,\"p.value\":0,\"nobs\":25,\"df.residual\":22},{\"term\":\"hyp\",\"estimate\":1.5843,\"std.error\":2.236,\"statistic\":0.7086,\"p.value\":0.486,\"nobs\":25,\"df.residual\":22},{\"term\":\"chl\",\"estimate\":-0.0032,\"std.error\":0.0205,\"statistic\":-0.1569,\"p.value\":0.8768,\"nobs\":25,\"df.residual\":25}]}"
+          example: "{\"data\": [{\"term\":\"(Intercept)\",\"estimate\":23.9357,\"std.error\":3.8732,
+              \"statistic\":6.1798,\"p.value\":3.2106e-06,\"nobs\":25,\"df.residual\":22},
+              {\"term\":\"hyp\",\"estimate\":1.1677,\"std.error\":1.6218,\"statistic\":0.72,
+              \"p.value\":0.4791,\"nobs\":25,\"df.residual\":22},{\"term\":\"chl\",\"estimate\":0.0063,
+              \"std.error\":0.0185,\"statistic\":0.3385,\"p.value\":0.7382,\"nobs\":25,\"df.residual\":22},
+              {\"term\":\"(Intercept)\",\"estimate\":24.5434,\"std.error\":4.7611,\"statistic\":5.155,
+              \"p.value\":0,\"nobs\":25,\"df.residual\":22},{\"term\":\"hyp\",\"estimate\":1.5843,
+              \"std.error\":2.236,\"statistic\":0.7086,\"p.value\":0.486,\"nobs\":25,\"df.residual\":22},
+              {\"term\":\"chl\",\"estimate\":-0.0032,\"std.error\":0.0205,\"statistic\":-0.1569,
+              \"p.value\":0.8768,\"nobs\":25,\"df.residual\":25}]}"
           required: true
       responses:
         200:
@@ -141,4 +164,7 @@ paths:
             text/json:
               schema:
                 type: string
-                example: "[{\"term\":\"(Intercept)\",\"m\":2,\"estimate\":24.2396,\"std.error\":4.3717,\"statistic\":5.5446,\"df\":19.8636,\"p.value\":0,\"conf.low\":15.1163,\"conf.high\":33.3628,\"riv\":0.0147,\"lambda\":0.0145,\"fmi\":0.1007,\"ubar\":18.8351,\"b\":0.1846,\"t\":19.112,\"dfcom\":22}]"
+                example: {"term":"(Intercept)","m":2,"estimate":24.2396,"std.error":4.3717,
+                    "statistic":5.5446,"df":19.8636,"p.value":0,"conf.low":15.1163,
+                    "conf.high":33.3628,"riv":0.0147,"lambda":0.0145,"fmi":0.1007,
+                    "ubar":18.8351,"b":0.1846,"t":19.112,"dfcom":22}

--- a/sanitize_input.R
+++ b/sanitize_input.R
@@ -1,0 +1,142 @@
+#' Takes a dataframe and checks for all columns thta consist of strings that there are only 50
+#' unique values.
+#'
+#' @param data An R dataframe
+check_factors <- function(data) {
+  cols <- names(data)
+  for (c in cols) {
+    if (unique(sapply(data[[c]], typeof)) == list('character') & length(levels(factor(data[[c]]))) > 50) {
+      return(paste("Too many factors", c, length(levels(factor(data[[c]])))))
+    }
+  }
+  return("")
+}
+
+
+#' Takes the content of the data parameter from a call to the impute endpoint
+#' and returns a dataframe.
+#'
+#' @param param_data A string with the name of the dataset, a hash from an
+#' uploaded file, or a csv file
+sanitize_data <- function(param_data) {
+  return_list <- list()
+  result <- tryCatch(
+    {
+      data <- get(param_data)
+    },
+    error = function(e) {
+      return(FALSE)
+    }
+  )
+
+  if (typeof(result) == "list") {
+    print("DEBUG: Imputation on example data set")
+    check <- check_factors(data)
+    if (check == "") {
+      return_list$df <- data
+      return(return_list)
+    } else {
+      return_list$error <- check
+      return(return_list)
+    }
+  }
+
+  if (typeof(param_data) == "character" && endsWith(param_data, ".csv")) {
+    print("DEBUG: Imputation on local csv file")
+    df <- read_file(param_data)
+    if (is.null(df)) {
+      return_list$error <- "Failure: reading local csv file"
+    }
+    else {
+      check <- check_factors(df)
+      if (check == "") {
+        return_list$df <- df
+      } else {
+        return_list$error <- check
+      }
+    }
+    return(return_list)
+  }
+
+  if (typeof(param_data) == "character") {
+    print("DEBUG: Imputation on uploaded file")
+    df <- read_file(file.path(get_data_uploads(), param_data))
+    if (is.null(df)) {
+      return_list$error <-
+        "Failure: reading file, not an example dataset or file on server"
+    }
+    else {
+      check <- check_factors(df)
+      if (check == "") {
+        return_list$df <- df
+      } else {
+        return_list$error <- check
+      }
+    }
+    return(return_list)
+  }
+
+  return_list$error <- "Failure: unrecognized format for `data` parameter."
+  return(return_list)
+}
+
+#' Takes the content of the predictorMatrix parameter from a call to the impute
+#' endpoint and returns a matrix.
+#'
+#' @param param_pred A matrix of size p \* p or a vector of length p \* p (where
+#' p is the number of columns in the dataset) that can be converted to a square
+#' matrix (reading by row). The order of variables in the matrix is assumed to
+#' correspond to the order of the columns in the dataset.
+#' @param nvar Number of columns in the dataset.
+sanitize_predictorMatrix <- function(param_pred, nvar) {
+  return_list <- list()
+
+  if (is.vector(param_pred)) {
+    if (length(param_pred) != nvar * nvar) {
+      return_list$error <-
+        "Failure: predictorMatrix is not of the correct size."
+      return(return_list)
+    }
+    param_pred <- matrix(param_pred, nrow = nvar, byrow = TRUE)
+  }
+
+  if (is.matrix(param_pred)) {
+    if (nrow(param_pred) != ncol(param_pred)) {
+      return_list$error <- "Failure: predictorMatrix is not square."
+      return(return_list)
+    }
+    if (ncol(param_pred) != nvar) {
+      return_list$error <-
+        "Failure: predictorMatrix is not of the correct size."
+      return(return_list)
+    }
+    if (!all(param_pred %in% c(0, 1))) {
+      return_list$error <-
+        "Failure: predictorMatrix contains non-binary values."
+      return(return_list)
+    }
+    return_list$pm <- param_pred
+    return(return_list)
+  }
+
+  return_list$error <- 
+    "Failure: unrecognized format for `predictorMatrix` parameter."
+  return(return_list)
+}
+
+sanitize_parcel <- function(parcel_input) {
+  return_list <- list()
+  result <- tryCatch(
+    {
+      return_list$parcel <- make.parcel(parcel_input)
+    },
+    error = function(e) {
+      return(e)
+    }
+  )
+  if (is.null(return_list$parcel)) {
+    print(error)
+    return_list$error <- result
+  }
+  return(return_list)
+}

--- a/sanitize_input.R
+++ b/sanitize_input.R
@@ -9,7 +9,7 @@ check_factors <- function(data) {
       return(paste("Too many factors", c, length(levels(factor(data[[c]])))))
     }
   }
-  return("")
+  return(NULL)
 }
 
 
@@ -32,7 +32,7 @@ sanitize_data <- function(param_data) {
   if (typeof(result) == "list") {
     print("DEBUG: Imputation on example data set")
     check <- check_factors(data)
-    if (check == "") {
+    if (is.null(check)) {
       return_list$df <- data
       return(return_list)
     } else {

--- a/webmice.R
+++ b/webmice.R
@@ -16,6 +16,7 @@ if(base_folder == "") {
 #' Imports
 source(file.path(base_folder, "webmice_handlers.R"))
 source(file.path(base_folder, "webmice_functions.R"))
+source(file.path(base_folder, "sanitize_input.R"))
 
 #' Data upload location
 data_uploads = file.path(base_folder, "data_uploads")

--- a/webmice_functions.R
+++ b/webmice_functions.R
@@ -68,10 +68,10 @@ sanitize_data <- function(param_data) {
       data <- get(param_data)
     },
     error = function(e) {
-      return(-1)
+      return(FALSE)
     }
   )
-  
+
   if (typeof(result) == "list") {
     print("DEBUG: Imputation on example data set")
     check <- check_factors(data)
@@ -177,13 +177,14 @@ imp_result_long_fmt <- function(imp) {
 
 #' Mice functions
 #' @inheritParams mice::mice
-impute <- function(data, maxit, m, seed, predictorMatrix) {
+impute <- function(data, maxit, m, seed, predictorMatrix, blocks) {
   imp <- list()
   imp$error <- ""
   result <- tryCatch(
     {
       imp <- mice(data, maxit = maxit, m = m, seed = seed,
-                  predictorMatrix = predictorMatrix)
+                  predictorMatrix = predictorMatrix, 
+                  blocks = blocks)
       return(imp)
     },
     error = function(e) {
@@ -228,11 +229,17 @@ call_mice <- function(params) {
     pm <- san_pm$pm
   }
 
+  if (is.null(params$blocks)) {
+    params$blocks <- names(df)
+  }
+
   if (is.null(params$m)) {
     params$m <- 5 #default value
   }
 
-  imp <- impute(df, maxit = params$maxit, m = params$m, seed = params$seed,
+  imp <- impute(df, maxit = params$maxit, m = params$m, 
+                seed = params$seed,
+                blocks = params$blocks,
                 predictorMatrix = pm)
   return(imp)
 }

--- a/webmice_functions.R
+++ b/webmice_functions.R
@@ -41,132 +41,6 @@ json_to_parameters <- function(json_payload) {
   )
 }
 
-#' Takes a dataframe and checks for all columns thta consist of strings that there are only 50
-#' unique values.
-#'
-#' @param data An R dataframe
-check_factors <- function(data) {
-  cols <- names(data)
-  for (c in cols) {
-    if (unique(sapply(data[[c]], typeof)) == list('character') & length(levels(factor(data[[c]]))) > 50) {
-      return(paste("Too many factors", c, length(levels(factor(data[[c]])))))
-    }
-  }
-  return("")
-}
-
-
-#' Takes the content of the data parameter from a call to the impute endpoint
-#' and returns a dataframe.
-#'
-#' @param param_data A string with the name of the dataset, a hash from an
-#' uploaded file, or a csv file
-sanitize_data <- function(param_data) {
-  return_list <- list()
-  result <- tryCatch(
-    {
-      data <- get(param_data)
-    },
-    error = function(e) {
-      return(FALSE)
-    }
-  )
-
-  if (typeof(result) == "list") {
-    print("DEBUG: Imputation on example data set")
-    check <- check_factors(data)
-    if (check == "") {
-      return_list$df <- data
-      return(return_list)
-    } else {
-      return_list$error <- check
-      return(return_list)
-    }
-  }
-
-  if (typeof(param_data) == "character" && endsWith(param_data, ".csv")) {
-    print("DEBUG: Imputation on local csv file")
-    df <- read_file(param_data)
-    if (is.null(df)) {
-      return_list$error <- "Failure: reading local csv file"
-    }
-    else {
-      check <- check_factors(df)
-      if (check == "") {
-        return_list$df <- df
-      } else {
-        return_list$error <- check
-      }
-    }
-    return(return_list)
-  }
-
-  if (typeof(param_data) == "character") {
-    print("DEBUG: Imputation on uploaded file")
-    df <- read_file(file.path(get_data_uploads(), param_data))
-    if (is.null(df)) {
-      return_list$error <-
-        "Failure: reading file, not an example dataset or file on server"
-    }
-    else {
-      check <- check_factors(df)
-      if (check == "") {
-        return_list$df <- df
-      } else {
-        return_list$error <- check
-      }
-    }
-    return(return_list)
-  }
-
-  return_list$error <- "Failure: unrecognized format for `data` parameter."
-  return(return_list)
-}
-
-#' Takes the content of the predictorMatrix parameter from a call to the impute
-#' endpoint and returns a matrix.
-#'
-#' @param param_pred A matrix of size p \* p or a vector of length p \* p (where
-#' p is the number of columns in the dataset) that can be converted to a square
-#' matrix (reading by row). The order of variables in the matrix is assumed to
-#' correspond to the order of the columns in the dataset.
-#' @param nvar Number of columns in the dataset.
-sanitize_predictorMatrix <- function(param_pred, nvar) {
-  return_list <- list()
-
-  if (is.vector(param_pred)) {
-    if (length(param_pred) != nvar * nvar) {
-      return_list$error <-
-        "Failure: predictorMatrix is not of the correct size."
-      return(return_list)
-    }
-    param_pred <- matrix(param_pred, nrow = nvar, byrow = TRUE)
-  }
-
-  if (is.matrix(param_pred)) {
-    if (nrow(param_pred) != ncol(param_pred)) {
-      return_list$error <- "Failure: predictorMatrix is not square."
-      return(return_list)
-    }
-    if (ncol(param_pred) != nvar) {
-      return_list$error <-
-        "Failure: predictorMatrix is not of the correct size."
-      return(return_list)
-    }
-    if (!all(param_pred %in% c(0, 1))) {
-      return_list$error <-
-        "Failure: predictorMatrix contains non-binary values."
-      return(return_list)
-    }
-    return_list$pm <- param_pred
-    return(return_list)
-  }
-
-  return_list$error <- 
-    "Failure: unrecognized format for `predictorMatrix` parameter."
-  return(return_list)
-}
-
 #' Takes the result of the imputation and returns the long format of the data
 #'
 #' @param imp Multiply imputed data set, an object of class \link[mice]{mids}
@@ -177,14 +51,15 @@ imp_result_long_fmt <- function(imp) {
 
 #' Mice functions
 #' @inheritParams mice::mice
-impute <- function(data, maxit, m, seed, predictorMatrix, blocks) {
+impute <- function(data, maxit, m, seed, 
+                   blocks, parcel, predictorMatrix) {
   imp <- list()
   imp$error <- ""
   result <- tryCatch(
     {
       imp <- mice(data, maxit = maxit, m = m, seed = seed,
                   predictorMatrix = predictorMatrix, 
-                  blocks = blocks)
+                  blocks = blocks, parcel = parcel)
       return(imp)
     },
     error = function(e) {
@@ -219,8 +94,7 @@ call_mice <- function(params) {
 
   if (is.null(params$predictorMatrix)) {
     pm <- make.predictorMatrix(df)
-  }
-  else {
+  } else {
     san_pm <- sanitize_predictorMatrix(params$predictorMatrix, nvar)
     if (!is.null(san_pm$error)) {
       imp$error <- san_pm$error
@@ -233,13 +107,26 @@ call_mice <- function(params) {
     params$blocks <- names(df)
   }
 
+  if (is.null(params$parcel)) {
+    parcel <- NULL
+  } else {
+    san_parcel <- sanitize_parcel(params$parcel)
+    print(san_parcel)
+    if (!is.null(san_parcel$error)) {
+      imp$error <- san_parcel$error
+      return(imp)
+    }
+    parcel <- san_parcel$parcel
+  }
+
   if (is.null(params$m)) {
     params$m <- 5 #default value
   }
-
+  
   imp <- impute(df, maxit = params$maxit, m = params$m, 
                 seed = params$seed,
                 blocks = params$blocks,
+                parcel = parcel,
                 predictorMatrix = pm)
   return(imp)
 }

--- a/webmice_handlers.R
+++ b/webmice_handlers.R
@@ -135,7 +135,7 @@ impute_longfmt_handler <- function(.req, .res) {
       impute$success <- FALSE
       impute$error <- imp$error
     }
-    .res$set_body(toJSON(impute, force=TRUE))
+    .res$set_body(toJSON(impute, force = TRUE))
     .res$set_content_type("text/plain")
   }
 }

--- a/webmice_handlers.R
+++ b/webmice_handlers.R
@@ -135,7 +135,7 @@ impute_longfmt_handler <- function(.req, .res) {
       impute$success <- FALSE
       impute$error <- imp$error
     }
-    .res$set_body(toJSON(impute))
+    .res$set_body(toJSON(impute, force=TRUE))
     .res$set_content_type("text/plain")
   }
 }


### PR DESCRIPTION
Disclaimer: the name of the branch is misleading.
Here is what changed:
- Dockerfile: direct to `support_blocks` branch in mice GitHub
-  Some formatting of the openapi.yaml for easier editing
- Addition of the `blocks` parameter to the mice function
- Addition of the `parcel` parameter to the mice function
- Moving the checks on the input parameters to an own file