### PR TITLE
Add dots argument

### DIFF
--- a/Documentation_endpoints.md
+++ b/Documentation_endpoints.md
@@ -53,3 +53,8 @@ Optional arguments:
 
  Example:
 > "formulas":["bmi ~ age", "bmi ~ hyp"]
+
+- *"dots"*: a named list of with for each parcel (optionally) a list of argments to pass down optional arguments to lower level imputation functions.
+
+ Example:
+> "dots":{"age":{"donor":20}} 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -88,7 +88,7 @@ paths:
           description: "Json with keys \"data\", \"maxit\", \"m\", \"seed\", 
               \"predictorMatrix\" (optional), \"blocks\" (optional), \"ignore\" (optional),
               \"where\" (optional), \"visitSeq\" (optional), \"method\" (optional), 
-              \"formula\" (optional)" 
+              \"formula\" (optional), \"dots\" (optional)" 
           in: query
           schema:
             type: string

--- a/sanitize_input.R
+++ b/sanitize_input.R
@@ -239,3 +239,42 @@ sanitize_formula <- function(param_formula, parcel_names) {
   return_list <- valid_formulas
   return(return_list)
 }
+
+#' Takes the content of the dots parameter from a call to the impute endpoint
+#' and returns a named list.
+#'
+#' @param param_where A named list containing at most q lists (one for each
+#' parcel) of arguments to pass down to other imputation methods.
+#' @param parcel_names Parcel names or dataset variable names
+sanitize_dots <- function(param_dots, parcel_names) {
+  return_list <- list()
+  
+  if (is.list(param_dots)) {
+    if (length(unique(names(param_dots))) < length(names(param_dots))) {
+      return_list$error <- 
+        "Failure: duplicate names in `dots` argument."
+      return(return_list)
+    }
+
+    if (!all(names(param_dots) %in% parcel_names)) {
+      return_list$error <- 
+        "Failure: unknown key(s) in `dots` argument."
+      return(return_list)
+    }
+    
+    for (dot in param_dots) {
+      if (!is.list(dot)) {
+        return_list$error <- 
+          "Failure: unrecognized format for element in `dots` parameter."
+        return(return_list)
+      }
+    }
+
+    return_list$dot <- param_dots
+    return(return_list)
+  }
+
+  return_list$error <- 
+    "Failure: unrecognized format for `dots` parameter."
+  return(return_list)
+}

--- a/webmice_functions.R
+++ b/webmice_functions.R
@@ -53,7 +53,7 @@ imp_result_long_fmt <- function(imp) {
 #' @inheritParams mice::mice
 impute <- function(data, maxit, m, seed, 
                    blocks, parcel, predictorMatrix, ignore, where,
-                   visitSequence, method) {
+                   visitSequence, method, dots) {
   imp <- list()
   imp$error <- ""
   result <- tryCatch(
@@ -62,7 +62,8 @@ impute <- function(data, maxit, m, seed,
                   predictorMatrix = predictorMatrix, 
                   blocks = blocks, parcel = parcel,
                   ignore = ignore, where = where,
-                  visitSequence = visitSequence, method = method
+                  visitSequence = visitSequence, method = method,
+                  dots = dots
       )
       return(imp)
     },
@@ -186,6 +187,21 @@ call_mice <- function(params) {
     }
   }
   
+  if (is.null(params$dots)) {
+    dots <- NULL
+  } else {
+    if (is.null(params$parcel)) {
+      san_dot <- sanitize_dots(params$dots, names(df))
+    } else {
+      san_dot <- sanitize_dots(params$dots, names(parcel))
+    }
+    if (!is.null(san_dot$error)) {
+      imp$error <- san_dot$error
+      return(imp)
+    }
+    dots <- san_dot$dot
+  }
+  
   imp <- impute(df, maxit = params$maxit, m = params$m, 
                 seed = params$seed,
                 blocks = params$blocks,
@@ -194,7 +210,8 @@ call_mice <- function(params) {
                 ignore = ign,
                 where = whr, 
                 visitSequence = visitSeq,
-                method = method
+                method = method,
+                dots = dots
                 )
   return(imp)
 }


### PR DESCRIPTION
Implements the `dots` argument, but not the `...` argument. I think it makes sense to leave it out in the API definition, as it is an R-specific feature that, I believe, does not add any functionality that is not already covered by the `dots` argument.

Also contains the changes within #18, so merge that first.